### PR TITLE
feat: implement reposts sync (twitterdump-10)

### DIFF
--- a/src/tweethoarder/client/timelines.py
+++ b/src/tweethoarder/client/timelines.py
@@ -284,6 +284,12 @@ def _convert_twitter_date_to_iso8601(twitter_date: str | None) -> str | None:
     return parsed.isoformat()
 
 
+def is_repost(raw_tweet: dict[str, Any]) -> bool:
+    """Check if a raw tweet is a repost (retweet)."""
+    legacy = raw_tweet.get("legacy", {})
+    return "retweeted_status_result" in legacy
+
+
 def extract_tweet_data(raw_tweet: dict[str, Any]) -> dict[str, Any] | None:
     """Extract and convert raw tweet data to database format.
 

--- a/tests/cli/test_sync_reposts.py
+++ b/tests/cli/test_sync_reposts.py
@@ -1,0 +1,193 @@
+"""Tests for user reposts sync functionality."""
+
+from pathlib import Path
+
+import pytest
+
+
+def test_sync_reposts_async_function_exists() -> None:
+    """sync_reposts_async function should be importable."""
+    from tweethoarder.cli.sync import sync_reposts_async
+
+    assert callable(sync_reposts_async)
+
+
+def test_is_repost_exists() -> None:
+    """is_repost function should be importable."""
+    from tweethoarder.client.timelines import is_repost
+
+    assert callable(is_repost)
+
+
+def test_is_repost_detects_retweet() -> None:
+    """is_repost should return True for tweets with retweeted_status_result."""
+    from tweethoarder.client.timelines import is_repost
+
+    retweet = {"legacy": {"retweeted_status_result": {"result": {"rest_id": "123"}}}}
+
+    assert is_repost(retweet) is True
+
+
+def test_is_repost_returns_false_for_regular_tweet() -> None:
+    """is_repost should return False for regular tweets."""
+    from tweethoarder.client.timelines import is_repost
+
+    regular_tweet = {"legacy": {"full_text": "Hello world"}}
+
+    assert is_repost(regular_tweet) is False
+
+
+@pytest.mark.asyncio
+async def test_sync_reposts_async_syncs_reposts(tmp_path: Path) -> None:
+    """sync_reposts_async should sync only reposts to database."""
+    from unittest.mock import AsyncMock, MagicMock, patch
+
+    from tweethoarder.cli.sync import sync_reposts_async
+
+    db_path = tmp_path / "test.db"
+
+    # Response with one regular tweet and one repost
+    mock_response = {
+        "data": {
+            "user": {
+                "result": {
+                    "timeline_v2": {
+                        "timeline": {
+                            "instructions": [
+                                {
+                                    "type": "TimelineAddEntries",
+                                    "entries": [
+                                        {
+                                            "entryId": "tweet-123",
+                                            "content": {
+                                                "itemContent": {
+                                                    "tweet_results": {
+                                                        "result": {
+                                                            "rest_id": "123",
+                                                            "legacy": {
+                                                                "full_text": "Regular tweet",
+                                                                "created_at": "Wed Jan 01 12:00:00 +0000 2025",  # noqa: E501
+                                                                "conversation_id_str": "123",
+                                                            },
+                                                            "core": {
+                                                                "user_results": {
+                                                                    "result": {
+                                                                        "rest_id": "456",
+                                                                        "core": {
+                                                                            "screen_name": "testuser",  # noqa: E501
+                                                                            "name": "Test",
+                                                                        },
+                                                                    }
+                                                                }
+                                                            },
+                                                        }
+                                                    }
+                                                }
+                                            },
+                                        },
+                                        {
+                                            "entryId": "tweet-456",
+                                            "content": {
+                                                "itemContent": {
+                                                    "tweet_results": {
+                                                        "result": {
+                                                            "rest_id": "456",
+                                                            "legacy": {
+                                                                "full_text": "RT @other: Repost",
+                                                                "created_at": "Wed Jan 01 12:00:00 +0000 2025",  # noqa: E501
+                                                                "conversation_id_str": "456",
+                                                                "retweeted_status_result": {
+                                                                    "result": {"rest_id": "789"}
+                                                                },
+                                                            },
+                                                            "core": {
+                                                                "user_results": {
+                                                                    "result": {
+                                                                        "rest_id": "456",
+                                                                        "core": {
+                                                                            "screen_name": "testuser",  # noqa: E501
+                                                                            "name": "Test",
+                                                                        },
+                                                                    }
+                                                                }
+                                                            },
+                                                        }
+                                                    }
+                                                }
+                                            },
+                                        },
+                                    ],
+                                }
+                            ]
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    with (
+        patch("tweethoarder.cli.sync.resolve_cookies") as mock_cookies,
+        patch("tweethoarder.cli.sync.TwitterClient") as mock_client_class,
+        patch("tweethoarder.cli.sync.get_config_dir") as mock_config_dir,
+        patch("tweethoarder.cli.sync.get_query_id_with_fallback") as mock_get_query_id,
+        patch("tweethoarder.cli.sync.httpx.AsyncClient") as mock_async_client,
+    ):
+        mock_cookies.return_value = {"twid": "u%3D789"}
+        mock_client_class.return_value.get_base_headers.return_value = {}
+        mock_config_dir.return_value = tmp_path
+        mock_get_query_id.return_value = "ABC123"
+
+        mock_http = AsyncMock()
+        mock_http_response = MagicMock()
+        mock_http_response.json.return_value = mock_response
+        mock_http_response.raise_for_status = MagicMock()
+        mock_http.get.return_value = mock_http_response
+        mock_async_client.return_value.__aenter__.return_value = mock_http
+
+        result = await sync_reposts_async(db_path, count=10)
+
+        # Should only sync the repost, not the regular tweet
+        assert result["synced_count"] == 1
+
+
+def test_reposts_command_accepts_count_option() -> None:
+    """Reposts command should accept a --count option."""
+    from typer.testing import CliRunner
+
+    from tweethoarder.cli.sync import app
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["reposts", "--help"])
+
+    assert "--count" in result.output or "-c" in result.output
+
+
+def test_reposts_command_accepts_all_flag() -> None:
+    """Reposts command should accept an --all flag."""
+    from typer.testing import CliRunner
+
+    from tweethoarder.cli.sync import app
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["reposts", "--help"])
+
+    assert "--all" in result.output
+
+
+def test_reposts_command_calls_sync_reposts_async() -> None:
+    """Reposts command should call sync_reposts_async."""
+    from unittest.mock import AsyncMock, patch
+
+    from typer.testing import CliRunner
+
+    from tweethoarder.cli.sync import app
+
+    runner = CliRunner()
+
+    with patch("tweethoarder.cli.sync.sync_reposts_async", new_callable=AsyncMock) as mock_sync:
+        mock_sync.return_value = {"synced_count": 5}
+        result = runner.invoke(app, ["reposts", "--count", "10"])
+
+        mock_sync.assert_called_once()
+        assert "5" in result.output


### PR DESCRIPTION
## Summary
- Add `sync reposts` command to fetch and store user's retweets from Twitter
- Implement `is_repost` function to detect retweets by checking `retweeted_status_result`
- Add `sync_reposts_async` to sync only retweets from user's timeline
- Store synced reposts in 'repost' collection
- Reuse `UserTweets` endpoint and `parse_user_tweets_response`

## Test plan
- [x] All 197 tests pass
- [x] Lint checks pass
- [ ] Manual testing with real Twitter account

🤖 Generated with [Claude Code](https://claude.com/claude-code)