### PR TITLE
feat: implement thread command with thread/conversation modes

### DIFF
--- a/src/tweethoarder/cli/thread.py
+++ b/src/tweethoarder/cli/thread.py
@@ -1,0 +1,51 @@
+"""Thread fetching functionality for TweetHoarder CLI."""
+
+from pathlib import Path
+
+import httpx
+
+from tweethoarder.auth.cookies import resolve_cookies
+from tweethoarder.client.base import TwitterClient
+from tweethoarder.config import get_config_dir
+from tweethoarder.query_ids.store import get_query_id_with_fallback
+
+
+async def fetch_thread_async(
+    db_path: Path,
+    tweet_id: str,
+    mode: str = "thread",
+    limit: int = 200,
+) -> dict:
+    """Fetch thread for a tweet."""
+    from tweethoarder.client.timelines import (
+        extract_tweet_data,
+        fetch_tweet_detail_page,
+        filter_tweets_by_mode,
+        get_focal_tweet_author_id,
+        parse_tweet_detail_response,
+    )
+    from tweethoarder.query_ids.store import QueryIdStore
+    from tweethoarder.storage.database import save_tweet
+
+    cookies = resolve_cookies()
+    client = TwitterClient(cookies=cookies)
+    cache_path = get_config_dir() / "query-ids-cache.json"
+    store = QueryIdStore(cache_path)
+    query_id = get_query_id_with_fallback(store, "TweetDetail")
+
+    headers = client.get_base_headers()
+    tweet_count = 0
+
+    async with httpx.AsyncClient(headers=headers) as http_client:
+        response = await fetch_tweet_detail_page(http_client, query_id, tweet_id)
+        tweets = parse_tweet_detail_response(response)
+        author_id = get_focal_tweet_author_id(response, tweet_id)
+        tweets = filter_tweets_by_mode(tweets, mode, author_id)
+
+        for raw_tweet in tweets:
+            tweet_data = extract_tweet_data(raw_tweet)
+            if tweet_data:
+                save_tweet(db_path, tweet_data)
+                tweet_count += 1
+
+    return {"tweet_count": tweet_count}

--- a/src/tweethoarder/storage/database.py
+++ b/src/tweethoarder/storage/database.py
@@ -107,6 +107,14 @@ INDEXES = [
 ]
 
 
+def get_db_path() -> Path:
+    """Get the default database path."""
+    from tweethoarder.config import get_data_dir
+
+    data_dir: Path = get_data_dir()
+    return data_dir / "tweethoarder.db"
+
+
 def init_database(db_path: Path) -> None:
     """Initialize the SQLite database."""
     with sqlite3.connect(db_path) as conn:

--- a/tests/cli/test_thread.py
+++ b/tests/cli/test_thread.py
@@ -27,6 +27,54 @@ def test_thread_command_has_depth_option() -> None:
 
 def test_thread_command_displays_tweet_id() -> None:
     """Thread command should display the tweet ID being fetched."""
-    result = runner.invoke(app, ["thread", "1234567890"])
+    from unittest.mock import AsyncMock, patch
+
+    with patch("tweethoarder.cli.main.fetch_thread_async", new_callable=AsyncMock) as mock_fetch:
+        mock_fetch.return_value = {"tweet_count": 0}
+        result = runner.invoke(app, ["thread", "1234567890"])
+        assert result.exit_code == 0
+        assert "1234567890" in result.output
+
+
+def test_thread_command_has_mode_option() -> None:
+    """Thread command should have --mode option for thread vs conversation."""
+    import re
+
+    result = runner.invoke(app, ["thread", "--help"])
     assert result.exit_code == 0
-    assert "1234567890" in result.output
+    clean_output = re.sub(r"\x1b\[[0-9;]*m", "", result.output)
+    assert "--mode" in clean_output
+
+
+def test_thread_command_has_limit_option() -> None:
+    """Thread command should have --limit option for max tweets."""
+    import re
+
+    result = runner.invoke(app, ["thread", "--help"])
+    assert result.exit_code == 0
+    clean_output = re.sub(r"\x1b\[[0-9;]*m", "", result.output)
+    assert "--limit" in clean_output
+
+
+def test_thread_command_displays_mode_in_output() -> None:
+    """Thread command should display the mode in output."""
+    from unittest.mock import AsyncMock, patch
+
+    with patch("tweethoarder.cli.main.fetch_thread_async", new_callable=AsyncMock) as mock_fetch:
+        mock_fetch.return_value = {"tweet_count": 0}
+        result = runner.invoke(app, ["thread", "1234567890", "--mode", "conversation"])
+        assert result.exit_code == 0
+        assert "conversation" in result.output.lower()
+
+
+def test_thread_command_does_not_crash_on_import() -> None:
+    """Thread command should not crash due to import errors."""
+    from unittest.mock import AsyncMock, patch
+
+    # Mock the async function to avoid real API calls
+    with patch("tweethoarder.cli.main.fetch_thread_async", new_callable=AsyncMock) as mock_fetch:
+        mock_fetch.return_value = {"tweet_count": 0}
+        result = runner.invoke(app, ["thread", "1234567890"])
+        # Should not have import error
+        assert "cannot import" not in str(result.exception or "")
+        assert result.exit_code == 0

--- a/tests/cli/test_thread_fetch.py
+++ b/tests/cli/test_thread_fetch.py
@@ -1,0 +1,290 @@
+"""Tests for thread fetching functionality."""
+
+from pathlib import Path
+
+import pytest
+
+
+def test_fetch_thread_async_exists() -> None:
+    """fetch_thread_async function should be importable."""
+    from tweethoarder.cli.thread import fetch_thread_async
+
+    assert callable(fetch_thread_async)
+
+
+@pytest.mark.asyncio
+async def test_fetch_thread_async_returns_result(tmp_path: Path) -> None:
+    """fetch_thread_async should return a result dict."""
+    from unittest.mock import AsyncMock, MagicMock, patch
+
+    from tweethoarder.cli.thread import fetch_thread_async
+    from tweethoarder.storage.database import init_database
+
+    mock_response = {
+        "data": {
+            "threaded_conversation_with_injections_v2": {
+                "instructions": [
+                    {
+                        "type": "TimelineAddEntries",
+                        "entries": [
+                            {
+                                "entryId": "tweet-123",
+                                "content": {
+                                    "itemContent": {
+                                        "tweet_results": {
+                                            "result": {
+                                                "rest_id": "123",
+                                                "legacy": {
+                                                    "full_text": "Hello world",
+                                                    "created_at": "Wed Jan 01 12:00:00 +0000 2025",
+                                                    "conversation_id_str": "123",
+                                                },
+                                                "core": {
+                                                    "user_results": {
+                                                        "result": {
+                                                            "rest_id": "456",
+                                                            "core": {
+                                                                "screen_name": "testuser",
+                                                                "name": "Test User",
+                                                            },
+                                                        }
+                                                    }
+                                                },
+                                            }
+                                        }
+                                    }
+                                },
+                            }
+                        ],
+                    }
+                ]
+            }
+        }
+    }
+
+    db_path = tmp_path / "test.db"
+    init_database(db_path)
+
+    with (
+        patch("tweethoarder.cli.thread.resolve_cookies") as mock_cookies,
+        patch("tweethoarder.cli.thread.TwitterClient") as mock_client_class,
+        patch("tweethoarder.cli.thread.get_config_dir") as mock_config_dir,
+        patch("tweethoarder.cli.thread.get_query_id_with_fallback") as mock_get_query_id,
+        patch("tweethoarder.cli.thread.httpx.AsyncClient") as mock_async_client,
+    ):
+        mock_cookies.return_value = {"twid": "u%3D789"}
+        mock_client_class.return_value.get_base_headers.return_value = {}
+        mock_config_dir.return_value = tmp_path
+        mock_get_query_id.return_value = "DETAIL123"
+
+        mock_http = AsyncMock()
+        mock_http_response = MagicMock()
+        mock_http_response.json.return_value = mock_response
+        mock_http_response.raise_for_status = MagicMock()
+        mock_http.get.return_value = mock_http_response
+        mock_async_client.return_value.__aenter__.return_value = mock_http
+
+        result = await fetch_thread_async(
+            db_path=db_path,
+            tweet_id="123",
+            mode="thread",
+            limit=200,
+        )
+
+        assert isinstance(result, dict)
+        assert "tweet_count" in result
+        assert result["tweet_count"] == 1
+
+
+@pytest.mark.asyncio
+async def test_fetch_thread_async_filters_in_thread_mode(tmp_path: Path) -> None:
+    """fetch_thread_async should filter to only author's tweets in thread mode."""
+    from unittest.mock import AsyncMock, MagicMock, patch
+
+    from tweethoarder.cli.thread import fetch_thread_async
+    from tweethoarder.storage.database import init_database
+
+    mock_response = {
+        "data": {
+            "threaded_conversation_with_injections_v2": {
+                "instructions": [
+                    {
+                        "type": "TimelineAddEntries",
+                        "entries": [
+                            {
+                                "entryId": "tweet-123",
+                                "content": {
+                                    "itemContent": {
+                                        "tweet_results": {
+                                            "result": {
+                                                "rest_id": "123",
+                                                "legacy": {
+                                                    "full_text": "Hello from author1",
+                                                    "created_at": "Wed Jan 01 12:00:00 +0000 2025",
+                                                },
+                                                "core": {
+                                                    "user_results": {
+                                                        "result": {
+                                                            "rest_id": "author1",
+                                                            "core": {"screen_name": "user1"},
+                                                        }
+                                                    }
+                                                },
+                                            }
+                                        }
+                                    }
+                                },
+                            },
+                            {
+                                "entryId": "tweet-456",
+                                "content": {
+                                    "itemContent": {
+                                        "tweet_results": {
+                                            "result": {
+                                                "rest_id": "456",
+                                                "legacy": {
+                                                    "full_text": "Hello from author2",
+                                                    "created_at": "Wed Jan 01 13:00:00 +0000 2025",
+                                                },
+                                                "core": {
+                                                    "user_results": {
+                                                        "result": {
+                                                            "rest_id": "author2",
+                                                            "core": {"screen_name": "user2"},
+                                                        }
+                                                    }
+                                                },
+                                            }
+                                        }
+                                    }
+                                },
+                            },
+                        ],
+                    }
+                ]
+            }
+        }
+    }
+
+    db_path = tmp_path / "test.db"
+    init_database(db_path)
+
+    with (
+        patch("tweethoarder.cli.thread.resolve_cookies") as mock_cookies,
+        patch("tweethoarder.cli.thread.TwitterClient") as mock_client_class,
+        patch("tweethoarder.cli.thread.get_config_dir") as mock_config_dir,
+        patch("tweethoarder.cli.thread.get_query_id_with_fallback") as mock_get_query_id,
+        patch("tweethoarder.cli.thread.httpx.AsyncClient") as mock_async_client,
+    ):
+        mock_cookies.return_value = {"twid": "u%3D789"}
+        mock_client_class.return_value.get_base_headers.return_value = {}
+        mock_config_dir.return_value = tmp_path
+        mock_get_query_id.return_value = "DETAIL123"
+
+        mock_http = AsyncMock()
+        mock_http_response = MagicMock()
+        mock_http_response.json.return_value = mock_response
+        mock_http_response.raise_for_status = MagicMock()
+        mock_http.get.return_value = mock_http_response
+        mock_async_client.return_value.__aenter__.return_value = mock_http
+
+        result = await fetch_thread_async(
+            db_path=db_path,
+            tweet_id="123",
+            mode="thread",
+            limit=200,
+        )
+
+        # With mode="thread" and focal tweet author "author1", only 1 tweet should be counted
+        assert result["tweet_count"] == 1
+
+
+@pytest.mark.asyncio
+async def test_fetch_thread_async_saves_tweets_to_db(tmp_path: Path) -> None:
+    """fetch_thread_async should save tweets to database."""
+    import sqlite3
+    from unittest.mock import AsyncMock, MagicMock, patch
+
+    from tweethoarder.cli.thread import fetch_thread_async
+    from tweethoarder.storage.database import init_database
+
+    mock_response = {
+        "data": {
+            "threaded_conversation_with_injections_v2": {
+                "instructions": [
+                    {
+                        "type": "TimelineAddEntries",
+                        "entries": [
+                            {
+                                "entryId": "tweet-123",
+                                "content": {
+                                    "itemContent": {
+                                        "tweet_results": {
+                                            "result": {
+                                                "rest_id": "123",
+                                                "legacy": {
+                                                    "full_text": "Hello world",
+                                                    "created_at": "Wed Jan 01 12:00:00 +0000 2025",
+                                                    "conversation_id_str": "123",
+                                                },
+                                                "core": {
+                                                    "user_results": {
+                                                        "result": {
+                                                            "rest_id": "456",
+                                                            "core": {
+                                                                "screen_name": "testuser",
+                                                                "name": "Test User",
+                                                            },
+                                                        }
+                                                    }
+                                                },
+                                            }
+                                        }
+                                    }
+                                },
+                            }
+                        ],
+                    }
+                ]
+            }
+        }
+    }
+
+    db_path = tmp_path / "test.db"
+    init_database(db_path)
+
+    with (
+        patch("tweethoarder.cli.thread.resolve_cookies") as mock_cookies,
+        patch("tweethoarder.cli.thread.TwitterClient") as mock_client_class,
+        patch("tweethoarder.cli.thread.get_config_dir") as mock_config_dir,
+        patch("tweethoarder.cli.thread.get_query_id_with_fallback") as mock_get_query_id,
+        patch("tweethoarder.cli.thread.httpx.AsyncClient") as mock_async_client,
+    ):
+        mock_cookies.return_value = {"twid": "u%3D789"}
+        mock_client_class.return_value.get_base_headers.return_value = {}
+        mock_config_dir.return_value = tmp_path
+        mock_get_query_id.return_value = "DETAIL123"
+
+        mock_http = AsyncMock()
+        mock_http_response = MagicMock()
+        mock_http_response.json.return_value = mock_response
+        mock_http_response.raise_for_status = MagicMock()
+        mock_http.get.return_value = mock_http_response
+        mock_async_client.return_value.__aenter__.return_value = mock_http
+
+        await fetch_thread_async(
+            db_path=db_path,
+            tweet_id="123",
+            mode="thread",
+            limit=200,
+        )
+
+    # Verify tweet was saved to database
+    conn = sqlite3.connect(db_path)
+    cursor = conn.execute("SELECT id, text FROM tweets WHERE id = ?", ("123",))
+    row = cursor.fetchone()
+    conn.close()
+
+    assert row is not None
+    assert row[0] == "123"
+    assert row[1] == "Hello world"

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -343,3 +343,10 @@ def test_init_database_creates_threads_indexes(tmp_path: Path) -> None:
 
     assert "idx_threads_conversation" in indexes
     assert "idx_threads_focal" in indexes
+
+
+def test_get_db_path_exists() -> None:
+    """get_db_path function should be importable."""
+    from tweethoarder.storage.database import get_db_path
+
+    assert callable(get_db_path)


### PR DESCRIPTION
## Summary
- Add --mode (thread|conversation) and --limit options to thread command
- Implement TweetDetail GraphQL API fetch with response parsing
- Add tweet filtering by mode (thread keeps author only, conversation keeps all)
- Save fetched tweets to database

## Test plan
- [x] Run `just test` - all 241 tests pass
- [x] Run `just lint` - all checks pass
- [ ] Manual test with real tweet ID

Implements twitterdump-bti. Unblocks twitterdump-bt4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)