### PR TITLE
feat: add query ID resilience with static fallbacks

### DIFF
--- a/src/tweethoarder/cli/sync.py
+++ b/src/tweethoarder/cli/sync.py
@@ -160,7 +160,7 @@ async def sync_bookmarks_async(
         fetch_bookmarks_page,
         parse_bookmarks_response,
     )
-    from tweethoarder.query_ids.store import QueryIdStore
+    from tweethoarder.query_ids.store import QueryIdStore, get_query_id_with_fallback
     from tweethoarder.storage.database import add_to_collection, init_database, save_tweet
 
     init_database(db_path)
@@ -171,7 +171,7 @@ async def sync_bookmarks_async(
     client = TwitterClient(cookies)
     cache_path = get_config_dir() / "query-ids-cache.json"
     store = QueryIdStore(cache_path)
-    query_id = store.get("Bookmarks")
+    query_id = get_query_id_with_fallback(store, "Bookmarks")
     headers = client.get_base_headers()
     synced_count = 0
 

--- a/src/tweethoarder/query_ids/constants.py
+++ b/src/tweethoarder/query_ids/constants.py
@@ -24,6 +24,8 @@ FALLBACK_QUERY_IDS: dict[str, str] = {
     "TweetDetail": "97JF30KziU00483E_8elBA",
     "SearchTimeline": "M1jEez78PEfVfbQLvlWMvQ",
     "UserArticlesTweets": "8zBy9h4L90aDL02RsBcCFg",
+    "UserTweets": "HuTx74BxAnezK1gWvYY7zg",
+    "UserTweetsAndReplies": "RIWc55YCNyUJ-U3HHGYkdg",
     "Following": "BEkNpEt5pNETESoqMsTEGA",
     "Followers": "kuFUYP9eV1FPoEy4N-pi7w",
 }

--- a/tests/query_ids/test_store.py
+++ b/tests/query_ids/test_store.py
@@ -169,3 +169,44 @@ def test_save_persists_query_ids_to_disk(tmp_path: Path) -> None:
     assert cache_path.exists()
     assert store.get_query_id("Bookmarks") == "new_id_123"
     assert store.get_query_id("Likes") == "new_id_456"
+
+
+def test_get_query_id_with_fallback_returns_user_tweets_fallback(tmp_path: Path) -> None:
+    """get_query_id_with_fallback should return UserTweets fallback when not cached."""
+    from tweethoarder.query_ids.constants import FALLBACK_QUERY_IDS
+    from tweethoarder.query_ids.store import QueryIdStore, get_query_id_with_fallback
+
+    cache_path = tmp_path / "nonexistent" / "cache.json"
+    store = QueryIdStore(cache_path=cache_path)
+
+    result = get_query_id_with_fallback(store, "UserTweets")
+
+    assert result == FALLBACK_QUERY_IDS["UserTweets"]
+
+
+def test_get_query_id_with_fallback_returns_user_tweets_and_replies_fallback(
+    tmp_path: Path,
+) -> None:
+    """get_query_id_with_fallback should return UserTweetsAndReplies fallback when not cached."""
+    from tweethoarder.query_ids.constants import FALLBACK_QUERY_IDS
+    from tweethoarder.query_ids.store import QueryIdStore, get_query_id_with_fallback
+
+    cache_path = tmp_path / "nonexistent" / "cache.json"
+    store = QueryIdStore(cache_path=cache_path)
+
+    result = get_query_id_with_fallback(store, "UserTweetsAndReplies")
+
+    assert result == FALLBACK_QUERY_IDS["UserTweetsAndReplies"]
+
+
+def test_get_query_id_with_fallback_raises_for_unknown_operation(tmp_path: Path) -> None:
+    """get_query_id_with_fallback should raise KeyError for unknown operation."""
+    import pytest
+
+    from tweethoarder.query_ids.store import QueryIdStore, get_query_id_with_fallback
+
+    cache_path = tmp_path / "nonexistent" / "cache.json"
+    store = QueryIdStore(cache_path=cache_path)
+
+    with pytest.raises(KeyError, match="Unknown operation"):
+        get_query_id_with_fallback(store, "NonexistentOperation")


### PR DESCRIPTION
## Summary
- Add UserTweets and UserTweetsAndReplies to FALLBACK_QUERY_IDS for resilience when cached query IDs are unavailable
- Fix bookmarks sync to use get_query_id_with_fallback instead of non-existent store.get() method

## Test plan
- [x] Run `just test` to verify all tests pass
- [x] Verify new fallback IDs are present in FALLBACK_QUERY_IDS
- [x] Verify bookmarks sync uses get_query_id_with_fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)