### PR TITLE
docs: fix repository clone URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ TweetHoarder uses cookie-based authentication to access Twitter's internal Graph
 
 ```bash
 # Clone the repository
-git clone https://github.com/yourusername/tweethoarder.git
+git clone https://github.com/tfriedel/tweethoarder.git
 cd tweethoarder
 
 # Install with uv


### PR DESCRIPTION
Updates the README installation instructions to use the actual repository URL.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the repository clone instructions to use the official GitHub URL instead of a placeholder link.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->