### PR TITLE
fix: update stale fallback query IDs

### DIFF
--- a/src/tweethoarder/query_ids/constants.py
+++ b/src/tweethoarder/query_ids/constants.py
@@ -28,7 +28,7 @@ FALLBACK_QUERY_IDS: dict[str, str] = {
     "UserTweetsAndReplies": "_P1zJA2kS9W1PLHKdThsrg",
     "Following": "BEkNpEt5pNETESoqMsTEGA",
     "Followers": "kuFUYP9eV1FPoEy4N-pi7w",
-    "HomeLatestTimeline": "iOEZpOdfekFsxSlPQCQtPg",
+    "HomeLatestTimeline": "g9NSjyYXOBsmMiP9TmYGaA",
     "UserByScreenName": "xmU6X_CKVnQ5lSrCbAmJsg",
     "UserHighlightsTweets": "tiFMbGHqHkzmL74fSDNzGA",
 }


### PR DESCRIPTION
## Summary

- `HomeLatestTimeline` query ID had rotated; the stale ID causes 422 `GRAPHQL_VALIDATION_FAILED` on every home feed request
- Scraped fresh IDs from Twitter JS bundles and updated the fallback table

## Test plan

- [ ] Run `tweethoarder sync feed` — should succeed (no 422)
- [ ] Or run `tweethoarder refresh-ids` to pull the latest IDs from live bundles

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated a fallback identifier used for loading the Home Latest timeline, which may improve timeline availability when the primary request fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->