### PR TITLE
fix: use browser headers for HTML discovery pages in refresh_query_ids

### DIFF
--- a/src/tweethoarder/cli/main.py
+++ b/src/tweethoarder/cli/main.py
@@ -102,8 +102,10 @@ def refresh_ids_command() -> None:
     from tweethoarder.query_ids.store import QueryIdStore
 
     async def run() -> dict[str, str]:
+        from tweethoarder.auth.cookies import resolve_cookies
+        cookies = resolve_cookies()
         async with httpx.AsyncClient() as client:
-            result: dict[str, str] = await refresh_query_ids(client)
+            result: dict[str, str] = await refresh_query_ids(client, cookies=cookies)
             return result
 
     ids = asyncio.run(run())

--- a/src/tweethoarder/cli/sync.py
+++ b/src/tweethoarder/cli/sync.py
@@ -326,7 +326,7 @@ async def sync_likes_async(
 
         async def refresh_and_get_likes_id() -> str:
             """Refresh query IDs and return the new Likes ID."""
-            new_ids: dict[str, str] = await refresh_query_ids(http_client, targets={"Likes"})
+            new_ids: dict[str, str] = await refresh_query_ids(http_client, targets={"Likes"}, cookies=cookies)
             store.save(new_ids)
             return new_ids["Likes"]
 
@@ -487,7 +487,7 @@ async def sync_bookmarks_async(
 
         async def refresh_and_get_bookmarks_id() -> str:
             """Refresh query IDs and return the new Bookmarks ID."""
-            new_ids: dict[str, str] = await refresh_query_ids(http_client, targets={"Bookmarks"})
+            new_ids: dict[str, str] = await refresh_query_ids(http_client, targets={"Bookmarks"}, cookies=cookies)
             store.save(new_ids)
             return new_ids["Bookmarks"]
 

--- a/src/tweethoarder/query_ids/scraper.py
+++ b/src/tweethoarder/query_ids/scraper.py
@@ -66,12 +66,26 @@ def extract_operations(bundle_content: str, targets: set[str]) -> dict[str, str]
     return discovered
 
 
+_HTML_HEADERS = {
+    "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
+    "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+    "Accept-Language": "en-US,en;q=0.5",
+}
+
+
 async def refresh_query_ids(
     client: httpx.AsyncClient,
     targets: set[str] | None = None,
     discovery_pages: list[str] | None = None,
+    cookies: dict[str, str] | None = None,
 ) -> dict[str, str]:
-    """Fetch discovery pages, download bundles, and extract query IDs."""
+    """Fetch discovery pages, download bundles, and extract query IDs.
+
+    Discovery pages return HTML (not JSON), so they need browser-like headers
+    rather than the API Bearer/x-csrf-token headers that `client` carries.
+    A separate httpx client is used for the HTML fetches; `client` is kept for
+    any caller that wants to reuse it for subsequent API calls.
+    """
     from .constants import TARGET_QUERY_ID_OPERATIONS
 
     if discovery_pages is None:
@@ -81,19 +95,28 @@ async def refresh_query_ids(
 
     discovered: dict[str, str] = {}
 
-    # Fetch first discovery page
-    response = await client.get(discovery_pages[0])
-    response.raise_for_status()
-    bundle_urls = extract_bundle_urls(response.text)
+    html_headers = dict(_HTML_HEADERS)
+    if cookies:
+        html_headers["Cookie"] = "; ".join(f"{k}={v}" for k, v in cookies.items())
 
-    # Try each bundle until all targets found
-    for bundle_url in bundle_urls:
-        if len(discovered) == len(targets):
-            break
-        bundle_response = await client.get(bundle_url)
-        bundle_response.raise_for_status()
-        remaining_targets = targets - discovered.keys()
-        new_ids = extract_operations(bundle_response.text, remaining_targets)
-        discovered.update(new_ids)
+    async with httpx.AsyncClient(
+        headers=html_headers, follow_redirects=True
+    ) as html_client:
+        bundle_urls: list[str] = []
+        for page in discovery_pages:
+            response = await html_client.get(page)
+            if response.status_code == 200:
+                bundle_urls = extract_bundle_urls(response.text)
+                if bundle_urls:
+                    break
+
+        for bundle_url in bundle_urls:
+            if len(discovered) == len(targets):
+                break
+            bundle_response = await html_client.get(bundle_url)
+            bundle_response.raise_for_status()
+            remaining_targets = targets - discovered.keys()
+            new_ids = extract_operations(bundle_response.text, remaining_targets)
+            discovered.update(new_ids)
 
     return discovered


### PR DESCRIPTION
## Summary

- `refresh_query_ids` was passing the API auth client (with `Bearer` token and `x-csrf-token`) when fetching Twitter's HTML discovery pages, causing 401 responses
- Twitter's discovery pages (`x.com`, `x.com/explore`, etc.) only serve HTML to browser-like requests; API auth headers cause them to reject the request
- Fix: use a dedicated `httpx.AsyncClient` with browser `User-Agent`/`Accept` headers for HTML page fetches, keeping the original client for subsequent API calls only
- Also tries all configured discovery pages (not just the first), so the scraper can fall back to `/explore` or `/notifications` if the homepage returns a non-200
- Added optional `cookies=` parameter so authenticated pages succeed where the unauthenticated homepage might not
- Passes `cookies=` through in the `refresh-ids` command and in the Likes/Bookmarks sync flows

## Test plan

- [ ] Run `tweethoarder refresh-ids` — should succeed and print `Refreshed N query IDs.` instead of returning 0 IDs due to 401
- [ ] Run `tweethoarder sync likes` and `tweethoarder sync bookmarks` — inline query ID refresh on 404 should work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)